### PR TITLE
Run postinstall script on macOS machines only

### DIFF
--- a/Distribution/postinstall.sh
+++ b/Distribution/postinstall.sh
@@ -1,5 +1,10 @@
 #!/bin/zsh
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-CLI="${SCRIPTPATH}/DetoxRecorderCLI"
+OS="$(uname)"
 
-codesign -fs - "${CLI}"
+if [[ $OS == 'Darwin' ]]; then
+  SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+  CLI="${SCRIPTPATH}/DetoxRecorderCLI"
+  
+  codesign -fs - "${CLI}"
+fi
+


### PR DESCRIPTION
Run postinstall script on macOS machines only to prevent breaking Linux based CI.

I have Jenkin CI which I run Linting and Jest tests on, and after installing detox-recorder it breaks at `yarn install` so I edit this postinstall script to check if the `OS` is `Darwin`(which means MacOS machine) if not it won't run anything to allow `yarn install` to complete successfully.

**Describe the Bug**
I have added detox-recorder to devDependencies now I can't do `yarn install` in my CI environment as they are Linux based (Docker image `node:14-alpine`).

**To Reproduce**
 - `npx react-native init ProjectX`
 - `cd ProjectX`
 - `yarn add --dev detox-recorder`
 - `docker run --rm -it --volume $(pwd):/app --workdir /app node:14-alpine sh`
 - `yarn install`

**Expected Behavior**
Installing all packages successfully.

**Actual Behavior**
```
/app # yarn install
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.2.1: The platform "linux" is incompatible with this module.
info "fsevents@2.2.1" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "@react-native-community/eslint-config > @typescript-eslint/eslint-plugin > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
[4/4] Building fresh packages...
[1/3] ⠄ core-js-pure
[2/3] ⠄ detox-recorder
error /app/node_modules/detox-recorder: Command failed.
Exit code: 127
Command: ./postinstall.sh
Arguments:
Directory: /app/node_modules/detox-recorder
Output:
```

**Screenshots**
<img width="1920" alt="Screen Shot 2020-11-27 at 3 55 30 PM" src="https://user-images.githubusercontent.com/10425180/100456410-fd86e280-30c8-11eb-8a51-e0acd9855c14.png">

**Environment**
 - macOS: [11.0.1]
 - Xcode: [12.2]
 - iOS Simulator Runtime: [iOS 14.1]
 - Detox Recorder Version: [1.0.146]
