### PR TITLE
update postinstall to use sh shell for wider compatibility

### DIFF
--- a/Distribution/postinstall.sh
+++ b/Distribution/postinstall.sh
@@ -1,7 +1,8 @@
-#!/bin/zsh
+#!/usr/bin/env bash
+
 OS="$(uname)"
 
-if [[ $OS == 'Darwin' ]]; then
+if [ $OS = 'Darwin' ]; then
   SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
   CLI="${SCRIPTPATH}/DetoxRecorderCLI"
   


### PR DESCRIPTION
Some Linux systems and Docker Images (Ubuntu, Debian, and Alpine for example) don't come with `Zsh Shell` out of the box, the only shell in common between macOS, Linux(and it's all variant) is `Sh Shell` so I update the script to use Sh instead of Zsh for wider compatibility.